### PR TITLE
🧹 Refactor duplicated Lat/Lon encoding logic in MapServer.java

### DIFF
--- a/src/main/java/MapServer.java
+++ b/src/main/java/MapServer.java
@@ -167,25 +167,30 @@ public class MapServer {
         long lastLon = 0;
         for (Point point : route) {
             long lat = Math.round(point.getLat() * 1e5);
-            long diffLat = lat - lastLat;
-            diffLat = diffLat < 0 ? ~(diffLat << 1) : diffLat << 1;
-            while (diffLat >= 0x20) {
-                result.append(Character.toChars((int) ((0x20 | (diffLat & 0x1f)) + 63)));
-                diffLat >>= 5;
-            }
-            result.append(Character.toChars((int) (diffLat + 63)));
+            encodeValue(lat, lastLat, result);
             lastLat = lat;
 
             long lon = Math.round(point.getLon() * 1e5);
-            long diffLon = lon - lastLon;
-            diffLon = diffLon < 0 ? ~(diffLon << 1) : diffLon << 1;
-            while (diffLon >= 0x20) {
-                result.append(Character.toChars((int) ((0x20 | (diffLon & 0x1f)) + 63)));
-                diffLon >>= 5;
-            }
-            result.append(Character.toChars((int) (diffLon + 63)));
+            encodeValue(lon, lastLon, result);
             lastLon = lon;
         }
         return result.toString();
+    }
+
+    /**
+     * Encodes a single value (latitude or longitude) into the result string builder.
+     *
+     * @param value     the value to encode.
+     * @param lastValue the previous value for delta encoding.
+     * @param result    the string builder to append the encoded value to.
+     */
+    private static void encodeValue(long value, long lastValue, StringBuilder result) {
+        long diff = value - lastValue;
+        diff = diff < 0 ? ~(diff << 1) : diff << 1;
+        while (diff >= 0x20) {
+            result.append(Character.toChars((int) ((0x20 | (diff & 0x1f)) + 63)));
+            diff >>= 5;
+        }
+        result.append(Character.toChars((int) (diff + 63)));
     }
 }


### PR DESCRIPTION
This PR addresses a code health issue in `MapServer.java` where the latitude and longitude encoding logic was duplicated.

### 🎯 What:
The duplicated bitwise shifting loop and character conversion logic within the `encode` method has been extracted into a new private static helper method `encodeValue(long value, long lastValue, StringBuilder result)`.

### 💡 Why:
This refactoring significantly reduces cognitive load and improves the maintainability of the `encode` method. It centralizes the core encoding logic, making it easier to read and less prone to errors if the encoding algorithm needs to be updated in the future.

### ✅ Verification:
- Created a standalone `VerifyEncode.java` script containing both the original and refactored logic.
- Asserted that both implementations produce the same output for a sample route.
- Successfully ran the script with sample inputs: `38.5, -120.2`, `40.7, -120.95`, `43.252, -126.453`.
- The temporary script was deleted after verification.

### ✨ Result:
A cleaner, more maintainable `MapServer.java` with zero duplication in its route encoding logic.

---
*PR created automatically by Jules for task [3773287556724127167](https://jules.google.com/task/3773287556724127167) started by @kevinlin1*